### PR TITLE
Fixes

### DIFF
--- a/src/Kaleidoscope-Hardware-Virtual.cpp
+++ b/src/Kaleidoscope-Hardware-Virtual.cpp
@@ -23,7 +23,9 @@
 #include <sstream>
 #include <string>
 
-Virtual::Virtual(void) {
+Virtual::Virtual(void) 
+   :  _readMatrixEnabled(true)
+{
 }
 
 void Virtual::setup(void) {
@@ -59,6 +61,9 @@ typedef struct {
 static rc getRCfromPhysicalKey(std::string keyname);
 
 void Virtual::readMatrix() {
+   
+   if(!_readMatrixEnabled) return;
+   
   std::stringstream sline;
   sline << getLineOfInput(anythingHeld());
   Mode mode = M_TAP;
@@ -111,6 +116,11 @@ void Virtual::readMatrix() {
         TAP;
     }
   }
+}
+
+void Virtual::setKeystate(byte row, byte col, keystate ks)
+{
+   keystates[row][col] = ks;
 }
 
 void Virtual::actOnMatrixScan() {

--- a/src/Kaleidoscope-Hardware-Virtual.h
+++ b/src/Kaleidoscope-Hardware-Virtual.h
@@ -35,6 +35,13 @@ typedef struct {
 
 class Virtual {
   public:
+     
+    typedef enum {
+      PRESSED,
+      NOT_PRESSED,
+      TAP,
+    } keystate;
+    
     Virtual(void);
     void setup(void);
 
@@ -47,23 +54,24 @@ class Virtual {
     void maskHeldKeys(void);
 
     void syncLeds(void) {}
-    void setCrgbAt(byte row, byte col, cRGB color) {}
-    void setCrgbAt(uint8_t i, cRGB color) {}
-    cRGB getCrgbAt(uint8_t i) { return CRGB(0,0,0); }
+    void setCrgbAt(byte /*row*/, byte /*col*/, cRGB /*color*/) {}
+    void setCrgbAt(uint8_t /*i*/, cRGB /*color*/) {}
+    cRGB getCrgbAt(uint8_t /*i*/) { return CRGB(0,0,0); }
     void scanMatrix(void) {
       readMatrix();
       actOnMatrixScan();
     }
+    
+    void setEnableReadMatrix(bool state) { _readMatrixEnabled = state; }
+    
+    void setKeystate(byte row, byte col, keystate ks);
 
   private:
-    typedef enum {
-      PRESSED,
-      NOT_PRESSED,
-      TAP,
-    } keystate;
 
     keystate keystates[ROWS][COLS];
-    keystate keystates_prev[ROWS][COLS];
+    keystate keystates_prev[ROWS][COLS];  
+    
+    bool _readMatrixEnabled;
 
     bool anythingHeld();
 

--- a/src/VirtualHID/Keyboard.h
+++ b/src/VirtualHID/Keyboard.h
@@ -21,6 +21,23 @@ typedef union {
   uint8_t allkeys[1 + KEY_BYTES];
 } HID_KeyboardReport_Data_t;
 
+class KeyboardReportConsumer_
+{
+   public:
+      
+      virtual ~KeyboardReportConsumer_() {}
+      virtual void processKeyboardReport(
+                     const HID_KeyboardReport_Data_t &reportData) = 0;
+};
+
+class StandardKeyboardReportConsumer : public KeyboardReportConsumer_
+{
+   public:
+      
+      virtual void processKeyboardReport(
+                     const HID_KeyboardReport_Data_t &reportData) override;
+};
+
 class Keyboard_ {
   public:
     Keyboard_(void);
@@ -34,10 +51,15 @@ class Keyboard_ {
 
     boolean isModifierActive(uint8_t k);
     boolean wasModifierActive(uint8_t k);
+    
+    void setKeyboardReportConsumer(
+            KeyboardReportConsumer_ &keyboardReportConsumer);
 
   protected:
     HID_KeyboardReport_Data_t _keyReport;
     HID_KeyboardReport_Data_t _lastKeyReport;
+    
+    KeyboardReportConsumer_ *_keyboardReportConsumer;
 };
 
 extern Keyboard_ Keyboard;

--- a/support/x86/cores/virtual/Stream.cpp
+++ b/support/x86/cores/virtual/Stream.cpp
@@ -1,0 +1,9 @@
+// The following are dummy implementations that saturate linkage
+
+#include "Stream.h"
+
+long 
+  Stream::parseInt(LookaheadMode lookahead, char ignore)
+{
+   return 0;
+}

--- a/support/x86/cores/virtual/main.cpp
+++ b/support/x86/cores/virtual/main.cpp
@@ -22,7 +22,7 @@
 #include <iostream>
 
 // Declared weak in Arduino.h to allow user redefinitions.
-int atexit(void (* /*func*/ )()) { return 0; }
+int atexit(void (* /*func*/ )()) throw () { return 0; }
 
 // Weak empty variant initialization function.
 // May be redefined by variant files.

--- a/support/x86/cores/virtual/stdlib_ext.h
+++ b/support/x86/cores/virtual/stdlib_ext.h
@@ -1,7 +1,7 @@
 // These functions are defined in the avr stdlib.h, but not the standard one
 // see descriptions in tools/avr/avr/include/stdlib.h
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -13,6 +13,6 @@ char *ultoa(unsigned long val, char* s, int radix);
 char *dtostre(double val, char* s, unsigned char prec, unsigned char flags);
 char *dtostrf(double val, signed char width, unsigned char prec, char* s);
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
The implementation of the Stream class is missing. I added only those missing parts to Stream.cpp that are needed to compile an executable based on Kaleidoscope-Hardware-Virtual. Without this, the symbol would be reported as undefined during linking.
    
The `_cplusplus` in stdlib_ext.h was misspelled it must actualy read `__cplusplus` to work. This does not cause problems when used with arduino-builder as it seems to compile everything as c++, even the calling object.

The missing `throw()` in main.cpp caused an error with x86 gcc 5.4.